### PR TITLE
Fix rating stars on iPhone

### DIFF
--- a/static/app.css
+++ b/static/app.css
@@ -70,7 +70,6 @@ order-status {
   left: 0;
   position: fixed;
   width: 100%;
-
 }
 
 order-status md-content {
@@ -93,9 +92,19 @@ order-status .ingredients-list {
   text-transform: capitalize;
 }
 
+order-status md-list-item.md-2-line .md-list-item-text h3 {
+  /* Wrap the title of the drink instead of letting it get cut off */
+  white-space: normal;
+}
+
 order-status .rating button {
-  font-size: 200%;
+  background-color: transparent;
   border: none;
+  font-size: 30px;
+  height: 45px;
+  padding: 0;
+  text-align: center;
+  width: 30px;
 }
 
 order-status .rating .filled {

--- a/static/components/order-status/order-status.html
+++ b/static/components/order-status/order-status.html
@@ -1,19 +1,23 @@
 <md-content flex layout-padding ng-class="{'no-orders': ctrl.svc.orders.length == 0}">
-  <md-list>
-    <md-list-item class="md-2-line" ng-repeat="order in ctrl.svc.orders">
-      <div class="md-list-item-text">
-        <h3 layout="row">
-          <span>{{order.drink_name}} for {{order.user_name}}</span>
-        </h3>
-        <p class="ingredients-list">{{ctrl.ingredientsCsv(order)}}</p>
-        <span class="md-secondary rating" ng-class="{'unrated': !order.rating}">
-          <button ng-repeat="i in [1, 2, 3, 4, 5]"
-                  ng-click="ctrl.rate(order, i)"
-                  ng-class="i <= (order.rating||0) ? 'filled' : 'empty'">
-            {{ i <= (order.rating || 0) ? "&#x2605;" : "&#x2606;" }}
-          </button>
-        </span>
+  <div ng-repeat="order in ctrl.svc.orders" layout="row">
+    <md-list flex="50">
+      <md-list-item class="md-2-line">
+        <div class="md-list-item-text">
+          <h3 layout="row">
+            {{order.drink_name}} for {{order.user_name}}
+          </h3>
+          <p class="ingredients-list">{{ctrl.ingredientsCsv(order)}}</p>
+        </div>
+      </md-list-item>
+    </md-list>
+    <span flex="50" layout="row" layout-align="space-between center" class="rating" ng-class="{'unrated': !order.rating}">
+      <div ng-repeat="i in [1, 2, 3, 4, 5]" flex>
+        <button
+                ng-click="ctrl.rate(order, i)"
+                ng-class="i <= (order.rating||0) ? 'filled' : 'empty'">
+          {{ i <= (order.rating || 0) ? "&#x2605;" : "&#x2606;" }}
+        </button>
       </div>
-    </md-list-item>
-  </md-list>
+    </span>
+  </div>
 </md-content>


### PR DESCRIPTION
I re-organized the HTML a bit, because the rating element didn't actually make sense in the list and was causing the drink information to get truncated.

I also put layout on the rating container and changed where the ng-repeat happens, so that the stars are properly spaced and centered in their div.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/57832/16213783/f4a95884-3706-11e6-9253-e6fd9c695185.png)
