### PR TITLE
Make name dialog modal for iOS 9.1.

### DIFF
--- a/static/components/order-drink/order-drink-service.ts
+++ b/static/components/order-drink/order-drink-service.ts
@@ -5,14 +5,14 @@ class OrderDrinkService {
 
   showOrderDrinkDialog(event: MouseEvent, recipe: Recipe) {
     return this.$mdDialog.show(<ng.material.IDialogOptions>{
-      clickOutsideToClose: true,
       controller: 'OrderDrinkDialogCtrl',
       controllerAs: 'ctrl',
       locals: {
         recipe: recipe
       },
       bindToController: true,
-      escapeToClose: true,
+      clickOutsideToClose: false,
+      escapeToClose: false,
       hasBackdrop: true,
       targetEvent: event,
       templateUrl: 'components/order-drink/order-drink-dialog.html',


### PR DESCRIPTION
The problem was apparently that the click/tap event for the name input was being misattributed and leading to the dialog getting dismissed. Turning of clickToClose and escapeToClose fixed it.

This is suboptimal for other platforms, but is a much cheaper fix than upgrading ng-material and not knowing if it's even going to provide relief.
