### PR TITLE
Don't let drinks be promoted in front of drinks currently being made.

### DIFF
--- a/nebree8.go
+++ b/nebree8.go
@@ -253,10 +253,17 @@ func cancelDrink(w http.ResponseWriter, r *http.Request) {
 func promoteDrink(w http.ResponseWriter, r *http.Request) {
 	var orders []Order
 	c := appengine.NewContext(r)
-	q := unpreparedDrinkQueryNewestFirst().Limit(1)
-	q.GetAll(c, &orders)
+	unpreparedDrinkQueryNewestFirst().GetAll(c, &orders)
+	var nextUnstartedOrder Order
+	for _, o := range orders {
+		if o.ProgressPercent == 0 {
+			nextUnstartedOrder = o
+			break
+		}
+	}
+
 	mutateAndReturnOrder(w, r, func(o *Order) error {
-		o.OrderTime = orders[0].OrderTime.Add(-1 * time.Minute)
+		o.OrderTime = nextUnstartedOrder.OrderTime.Add(-1 * time.Second)
 		return nil
 	})
 }

--- a/static/admin.ts
+++ b/static/admin.ts
@@ -73,8 +73,13 @@ class n8AdminCtrl {
         index = idx;
       }
     });
+
     this.queue.splice(index, 1);
-    this.queue.splice(0, 0, toTop);
+    var topIdx = 0;
+    if (this.queue[0].progress_percent > 0) {
+      topIdx = 1;
+    }
+    this.queue.splice(topIdx, 0, toTop);
 
     // Update the queue positions for drinks that are going to be made
     this.assignPositions();


### PR DESCRIPTION
I figured this out while I was working on the display, that the "promote" function was allowing drinks to be pushed in front of drinks currently being made.

I wasn't sure how the robot was going to handle that, but it seemed bad, so I fixed it.