### PR TITLE
Be explicit about charsets in app and admin.

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1,5 +1,6 @@
 <html ng-app="n8Admin">
 <head>
+  <meta charset="UTF-8">
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.11.4/angular-material.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">
   <link rel="stylesheet" href="app.css">

--- a/static/app.html
+++ b/static/app.html
@@ -1,5 +1,6 @@
 <html ng-app="nebree8App">
   <head>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.11.4/angular-material.min.css">
     <link rel="stylesheet" href="app.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">


### PR DESCRIPTION
This fixes a bug in Chrome 55 and later where the charset isn't automatically detected as UTF-8.